### PR TITLE
Added support for Bose-Hubbard propagation with nearest-neighbour interactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 cache: pip
 python:
+  - 3.5
   - 3.6
 env:
+  - LOGGING=info
 install:
   - pip install -r requirements.txt
   - pip install wheel codecov

--- a/doc/bosehubbard.rst
+++ b/doc/bosehubbard.rst
@@ -1,6 +1,6 @@
 .. role:: raw-latex(raw)
    :format: latex
-   
+
 .. role:: html(raw)
    :format: html
 
@@ -33,27 +33,30 @@ where:
 CV decomposition
 ----------------
 
-As the Bose-Hubbard Hamiltonian is time-independent, it suffices to find a continuous-variable (CV) gate decomposition for the unitary operator :math:`\hat{U}=e^{-i\hat{H}t}` :cite:`kalajdzievski2018`. Let's consider the case :math:`V=0` (i.e., no nearest-neighbour interactions). In this case, we can rewrite the Hamiltonian in the following form:
+As the Bose-Hubbard Hamiltonian is time-independent, it suffices to find a continuous-variable (CV) gate decomposition for the unitary operator :math:`\hat{U}=e^{-i\hat{H}t}` :cite:`kalajdzievski2018`. We can rewrite the Hamiltonian in the following form:
 
 
 .. math::
     \hat{H} = -J\sum_{i=1}^N\sum_{j=1}^N A_{ij} \ad_i\a_j
         + \sum_{\ell=1}^N \left(\frac{1}{2}U \hat{n}_\ell^2
-        - \left(\frac{1}{2}U+\mu\right) \hat{n}_\ell\right),
+        - \left(\frac{1}{2}U+\mu\right) \hat{n}_\ell\right)
+        + V \sum_{i=1}^N\sum_{j=1}^N \hat{n}_i\hat{n}_j,
 
 where :math:`\hat{n}_i=\ad_i\a_i` is the bosonic number operator. Taking the matrix exponential, and applying the Lie product formula,
 
 .. math::
-	e^{-iHt} = \lim_{k\rightarrow\infty}\left[\prod_{\substack{i,j\\i\sim j}}\exp\left({i\frac{ J t}{k}(\ad_i\a_j + \ad_j\a_i)}\right)\prod_{\ell}\exp\left(-i\frac{Ut}{2k}\hat{n}_\ell^2\right)\exp\left(i\frac{(U+2\mu)t}{2k}\hat{n}_\ell\right)\right]^k,
+	e^{-iHt} = \lim_{k\rightarrow\infty}\left[\prod_{\substack{i,j\\i\sim j}}\exp\left({i\frac{ J t}{k}(\ad_i\a_j + \ad_j\a_i)}\right)\exp\left({-i\frac{V t}{k}\hat{n}_i\hat{n}_j}\right)\prod_{\ell}\exp\left(-i\frac{Ut}{2k}\hat{n}_\ell^2\right)\exp\left(i\frac{(U+2\mu)t}{2k}\hat{n}_\ell\right)\right]^k,
 
 where :math:`i\sim j` indicates we are only summing over adjacent nodes (i.e., those where :math:`A_{ij}=1`). Truncating :math:`k` to a reasonable value, we end up with the approximation
 
 .. math::
-	e^{-iHt} = \left[\prod_{\substack{i,j\\i\sim j}}\exp\left({i\frac{ J t}{k}(\ad_i\a_j + \ad_j\a_i)}\right)\prod_{\ell}\exp\left(-i\frac{Ut}{2k}\hat{n}_\ell^2\right)\exp\left(i\frac{(U+2\mu)t}{2k}\hat{n}_\ell\right)\right]^k + \mathcal{O}(t^2/k).
+	e^{-iHt} = \left[\prod_{\substack{i,j\\i\sim j}}\exp\left({i\frac{ J t}{k}(\ad_i\a_j + \ad_j\a_i)}\right)\exp\left({-i\frac{V t}{k}\hat{n}_i\hat{n}_j}\right)\prod_{\ell}\exp\left(-i\frac{Ut}{2k}\hat{n}_\ell^2\right)\exp\left(i\frac{(U+2\mu)t}{2k}\hat{n}_\ell\right)\right]^k + \mathcal{O}(t^2/k).
 
-Comparing these individual bracketed operators with the known CV gate set (see `here <https://strawberryfields.readthedocs.io/en/latest/conventions/gates.html>`_ for more details) we see that they correspond to a beamsplitter, Kerr gate, and phase-space rotation respectively:
+Comparing these individual bracketed operators with the known CV gate set (see `here <https://strawberryfields.readthedocs.io/en/latest/conventions/gates.html>`_ for more details) we see that they correspond to a beamsplitter, cross-Kerr gate, Kerr gate, and phase-space rotation respectively:
 
 * :math:`\exp\left({i\frac{ J t}{k}(\ad_i\a_j + \ad_j\a_i)}\right)\equiv BS(\theta, \phi)` where :math:`\theta=Jt/k`, :math:`\phi=\pi/2`,
+
+* :math:`\exp\left({-i\frac{V t}{k}\hat{n}_i\hat{n}_j}\right)\equiv CK(\kappa)` where :math:`\kappa=-Vt/k`,
 
 * :math:`\exp\left(-i\frac{Ut}{2k}\hat{n}_\ell^2\right)\equiv K(\kappa)` where :math:`\kappa=-Ut/2k`,
 
@@ -64,10 +67,9 @@ Comparing these individual bracketed operators with the known CV gate set (see `
 .. admonition:: Decomposition
 	:class: defn
 
-	A Bose-Hubbard Hamiltonian with zero nearest-neighbour interactions can be implemented to arbitrary error via a decomposition of beamsplitters, Kerr gates, and phase-space rotations.
+	A Bose-Hubbard Hamiltonian can be implemented to arbitrary error via a decomposition of beamsplitters, cross-Kerr interactions, Kerr gates, and phase-space rotations.
 
 .. tip::
 
    *Implemented in SFOpenBoson as a quantum operation by* :class:`sfopenboson.ops.BoseHubbardPropagation`
-
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("sfopenboson/_version.py") as f:
 requirements = [
     "numpy>=1.13",
     "scipy>=1.0.0",
-    "strawberryfields>=0.7.3",
+    "strawberryfields>=0.8.0",
     "openfermion>=0.7"
 ]
 

--- a/sfopenboson/auxillary.py
+++ b/sfopenboson/auxillary.py
@@ -166,7 +166,11 @@ def extract_tunneling(H):
     if len(set(BS.values())) != 1:
         raise BoseHubbardError
 
-    return [list(BS.keys()), -t]
+    # check t is real
+    if t.imag != 0:
+        raise BoseHubbardError
+
+    return [list(BS.keys()), -t.real]
 
 
 def extract_onsite_chemical(H):
@@ -328,6 +332,8 @@ def trotter_layer(H, t, k):
               ``kappa`` acting on the list of modes provided.
             * ``'R': (r, modes)`` corresponding to rotation gates with parameter
               ``r`` acting on the list of modes provided.
+            * ``'CK': (kappa, modes)`` corresponding to a cross-Kerr interactions with parameter
+              ``kappa`` acting on the list of modes provided.
     """
     try:
         BS = extract_tunneling(H)
@@ -358,7 +364,7 @@ def trotter_layer(H, t, k):
         layer_dict['R'] = (t*U/(2*k), onsite[0])
 
     if dipole:
-        raise BoseHubbardError("Nearest-neighbour or dipole interactions "
-                               "not currently supported.")
+        V = dipole[1]
+        layer_dict['CK'] = (-t*V/k, dipole[0])
 
     return layer_dict

--- a/sfopenboson/ops.py
+++ b/sfopenboson/ops.py
@@ -326,7 +326,7 @@ class BoseHubbardPropagation(Decomposition):
                 cmds.append(Command(BS, (reg[q0], reg[q1])))
 
             if CK is not None:
-                for q0, q1 in self.layer['CK'][2]:
+                for q0, q1 in self.layer['CK'][1]:
                     cmds.append(Command(CK, (reg[q0], reg[q1])))
 
             if K is not None:

--- a/sfopenboson/ops.py
+++ b/sfopenboson/ops.py
@@ -81,6 +81,7 @@ from openfermion.transforms import get_quad_operator, get_boson_operator
 from openfermion.utils import is_hermitian, prune_unused_indices
 
 from strawberryfields.ops import (BSgate,
+                                  CKgate,
                                   Decomposition,
                                   GaussianTransform,
                                   Kgate,
@@ -138,7 +139,7 @@ class GaussianPropagation(Decomposition):
     """
     ns = None
     def __init__(self, operator, t=1, mode='local', hbar=None):
-        super().__init__([t, operator])
+        super().__init__([t])
 
         try:
             # pylint: disable=protected-access
@@ -243,8 +244,6 @@ class BoseHubbardPropagation(Decomposition):
     Lie-product formula, and decomposing the unitary operations into a combination
     of beamsplitters, Kerr gates, and phase-space rotations.
 
-    .. note:: Nearest-neighbour interactions (:math:`V\neq 0`) are not currently supported.
-
     Args:
         operator (BosonOperator, QuadOperator): a bosonic Gaussian Hamiltonian
         t (float): the time propagation value. If not provided, default value is 1.
@@ -259,7 +258,7 @@ class BoseHubbardPropagation(Decomposition):
     """
     ns = None
     def __init__(self, operator, t=1, k=20, mode='local', hbar=None):
-        super().__init__([t, operator])
+        super().__init__([t])
 
         try:
             # pylint: disable=protected-access
@@ -302,11 +301,23 @@ class BoseHubbardPropagation(Decomposition):
         phi = self.layer['BS'][1]
         BS = BSgate(theta, phi)
 
+        # make cross-Kerr gate
+        CK = None
+        param = self.layer.get('CK', [0])[0]
+        if param != 0:
+            CK = CKgate(param)
+
         # make Kerr gate
-        K = Kgate(self.layer['K'][0])
+        K = None
+        param = self.layer.get('K', [0])[0]
+        if param != 0:
+            K = Kgate(param)
 
         # make rotation gate
-        R = Rgate(self.layer['R'][0])
+        R = None
+        param = self.layer.get('R', [0])[0]
+        if param != 0:
+            R = Rgate(param)
 
         cmds = []
 
@@ -314,10 +325,16 @@ class BoseHubbardPropagation(Decomposition):
             for q0, q1 in self.layer['BS'][2]:
                 cmds.append(Command(BS, (reg[q0], reg[q1])))
 
-            for mode in self.layer['K'][1]:
-                cmds.append(Command(K, reg[mode]))
+            if CK is not None:
+                for q0, q1 in self.layer['CK'][2]:
+                    cmds.append(Command(CK, (reg[q0], reg[q1])))
 
-            for mode in self.layer['R'][1]:
-                cmds.append(Command(R, reg[mode]))
+            if K is not None:
+                for mode in self.layer['K'][1]:
+                    cmds.append(Command(K, reg[mode]))
+
+            if R is not None:
+                for mode in self.layer['R'][1]:
+                    cmds.append(Command(R, reg[mode]))
 
         return cmds

--- a/sfopenboson/tests/__init__.py
+++ b/sfopenboson/tests/__init__.py
@@ -12,3 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test module""" # pragma: no cover
+from defaults import BaseTest

--- a/sfopenboson/tests/__init__.py
+++ b/sfopenboson/tests/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test module""" # pragma: no cover
-from defaults import BaseTest
+from .defaults import BaseTest

--- a/sfopenboson/tests/defaults.py
+++ b/sfopenboson/tests/defaults.py
@@ -17,13 +17,10 @@ import os
 
 import unittest
 
-
-if "LOGGING" in os.environ:
-    logLevel = os.environ["LOGGING"]
-    print('Logging:', logLevel)
-    numeric_level = getattr(logging, logLevel.upper(), 10)
-else:
-    numeric_level = 100
+# Set the logging based on an environment variable.
+# default logging is set to WARNING.
+logLevel = os.environ.get("LOGGING", "WARNING")
+numeric_level = getattr(logging, logLevel.upper(), 10)
 
 
 logging.basicConfig(level=numeric_level, format='\n%(asctime)s %(levelname)s %(message)s', datefmt='%H:%M:%S')

--- a/sfopenboson/tests/defaults.py
+++ b/sfopenboson/tests/defaults.py
@@ -31,6 +31,8 @@ logging.captureWarnings(True)
 
 
 class BaseTest(unittest.TestCase):
+    """The base unit test class used by SFOpenBoson"""
 
     def logTestName(self):
-        logging.info('{}'.format(self.id()))
+        """Log the test method name at the information level"""
+        logging.info('%s', self.id())

--- a/sfopenboson/tests/defaults.py
+++ b/sfopenboson/tests/defaults.py
@@ -11,9 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Test defaults"""
+import logging
+import os
 
-"""Version information.
-   Version number (major.minor.patch[-label])
-"""
+import unittest
 
-__version__ = '0.2.0'
+
+if "LOGGING" in os.environ:
+    logLevel = os.environ["LOGGING"]
+    print('Logging:', logLevel)
+    numeric_level = getattr(logging, logLevel.upper(), 10)
+else:
+    numeric_level = 100
+
+
+logging.basicConfig(level=numeric_level, format='\n%(asctime)s %(levelname)s %(message)s', datefmt='%H:%M:%S')
+logging.captureWarnings(True)
+
+
+class BaseTest(unittest.TestCase):
+
+    def logTestName(self):
+        logging.info('{}'.format(self.id()))

--- a/sfopenboson/tests/test_auxillary.py
+++ b/sfopenboson/tests/test_auxillary.py
@@ -249,6 +249,14 @@ class TestExtractTunneling(BaseTest):
             H += BosonOperator('0^ 1', 1)
             extract_tunneling(H)
 
+    def test_complex_tunneling_coefficient(self):
+        """Test exception raised if the tunelling coefficient is complex"""
+        self.logTestName()
+        with self.assertRaises(BoseHubbardError):
+            H = BosonOperator('0 1^', 1+2j)
+            H += BosonOperator('0^ 1', 1+2j)
+            extract_tunneling(H)
+
     def test_tunneling_1x1(self):
         """Test exception raised 1x1 grid"""
         self.logTestName()

--- a/sfopenboson/tests/test_auxillary.py
+++ b/sfopenboson/tests/test_auxillary.py
@@ -39,8 +39,10 @@ from sfopenboson.hamiltonians import (displacement,
                                       controlled_addition,
                                       controlled_phase)
 
+from sfopenboson.tests import BaseTest
 
-class TestQuadraticCoefficients(unittest.TestCase):
+
+class TestQuadraticCoefficients(BaseTest):
     """Tests for quadratic_coefficients"""
     def setUp(self):
         """set up"""
@@ -48,16 +50,19 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_non_hermitian(self):
         """Test exception with non-Hermitian Hamiltonian"""
+        self.logTestName()
         with self.assertRaisesRegex(ValueError, "Hamiltonian must be Hermitian"):
             quadratic_coefficients(QuadOperator('q0 p0'))
 
     def test_non_gaussian(self):
         """Test exception with non-Gaussian Hamiltonian"""
+        self.logTestName()
         with self.assertRaisesRegex(ValueError, "Hamiltonian must be Gaussian"):
             quadratic_coefficients(QuadOperator('q0 p0 p1'))
 
     def test_displacement_vector(self):
         """Test displacement vector extracted"""
+        self.logTestName()
         H = QuadOperator('q0', -0.432) + QuadOperator('p0', 3.213)
         A, d = quadratic_coefficients(H)
         expected_A = np.zeros([2, 2])
@@ -75,6 +80,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_Dgate_displacement(self):
         """Test displacement vector matches Dgate"""
+        self.logTestName()
         a = 0.23-0.432j
         H, t = displacement(a, hbar=self.hbar)
         _, d = quadratic_coefficients(get_quad_operator(H, self.hbar))
@@ -84,6 +90,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_Xgate_displacement(self):
         """Test displacement vector matches Xgate"""
+        self.logTestName()
         x = 0.1234
         H, _ = xdisplacement(x)
         _, d = quadratic_coefficients(H)
@@ -92,6 +99,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_Zgate_displacement(self):
         """Test displacement vector matches Zgate"""
+        self.logTestName()
         z = 0.654
         H, _ = zdisplacement(z)
         _, d = quadratic_coefficients(H)
@@ -100,6 +108,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_rotation_coeff(self):
         """Test quadratic coefficients for Rgate"""
+        self.logTestName()
         # one mode
         H, _ = rotation(0.23, hbar=self.hbar)
         res, d = quadratic_coefficients(get_quad_operator(H, self.hbar))
@@ -118,6 +127,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_squeeze_coeff(self):
         """Test quadratic coefficients for Sgate"""
+        self.logTestName()
         # one mode
         # pylint: disable=invalid-unary-operand-type
         H, _ = squeezing(0.23, hbar=self.hbar)
@@ -137,6 +147,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_quadratic_phase_coeff(self):
         """Test quadratic coefficients for Pgate"""
+        self.logTestName()
         # one mode
         H, _ = quadratic_phase(0.23)
         res, d = quadratic_coefficients(H)
@@ -155,6 +166,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_beamsplitter_coeff(self):
         """Test quadratic coefficients for BSgate"""
+        self.logTestName()
         # arbitrary beamsplitter
         theta = 0.5423
         phi = 0.3242
@@ -170,6 +182,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_two_mode_squeeze_coeff(self):
         """Test quadratic coefficients for S2gate"""
+        self.logTestName()
         H, _ = two_mode_squeezing(0.23, hbar=self.hbar)
         res, d = quadratic_coefficients(get_quad_operator(H, self.hbar))
         expected = np.fliplr(np.diag([1]*4))
@@ -178,6 +191,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_controlled_addition(self):
         """Test quadratic coefficients for CXgate"""
+        self.logTestName()
         H, _ = controlled_addition(0.23)
         res, d = quadratic_coefficients(H)
         expected = np.fliplr(np.diag([1, 0, 0, 1]))
@@ -186,6 +200,7 @@ class TestQuadraticCoefficients(unittest.TestCase):
 
     def test_controlled_phase(self):
         """Test quadratic coefficients for CZgate"""
+        self.logTestName()
         H, _ = controlled_phase(0.23)
         res, d = quadratic_coefficients(H)
         expected = np.zeros([4, 4])
@@ -194,16 +209,18 @@ class TestQuadraticCoefficients(unittest.TestCase):
         self.assertTrue(np.allclose(d, np.zeros([4])))
 
 
-class TestExtractTunneling(unittest.TestCase):
+class TestExtractTunneling(BaseTest):
     """Test Bose-Hubbard tunnelling extracted from BosonOperator"""
     def test_no_tunneling(self):
         """Test exception raised for no tunneling"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 0, 0)
             extract_tunneling(H)
 
     def test_too_many_terms(self):
         """Test exception raised for wrong number of terms"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 0)
             H -= BosonOperator('0^ 1^')
@@ -217,6 +234,7 @@ class TestExtractTunneling(unittest.TestCase):
 
     def test_ladder_wrong_form(self):
         """Test exception raised for wrong ladder operators"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 0)
             H -= BosonOperator('5^ 6^')
@@ -225,6 +243,7 @@ class TestExtractTunneling(unittest.TestCase):
 
     def test_coefficients_differ(self):
         """Test exception raised for differing coefficients"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = BosonOperator('0 1^', 0.5)
             H += BosonOperator('0^ 1', 1)
@@ -232,12 +251,14 @@ class TestExtractTunneling(unittest.TestCase):
 
     def test_tunneling_1x1(self):
         """Test exception raised 1x1 grid"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(1, 1, 1, 0)
             extract_tunneling(H)
 
     def test_tunneling_1x2(self):
         """Test extracted tunneling on 1x2 grid"""
+        self.logTestName()
         H = bose_hubbard(1, 2, 0.5, 0)
         res = extract_tunneling(H)
         expected = [[(0, 1)], 0.5]
@@ -245,25 +266,30 @@ class TestExtractTunneling(unittest.TestCase):
 
     def test_tunneling_2x2(self):
         """Test extracted tunneling on 2x2 grid"""
+        self.logTestName()
         H = bose_hubbard(2, 2, 0.5, 0)
         res = extract_tunneling(H)
+        res[0] = sorted(res[0], key=lambda x: x[1])
         expected = [[(0, 1), (0, 2), (1, 3), (2, 3)], 0.5]
         self.assertEqual(res, expected)
 
     def test_tunneling_arbitrary(self):
         """Test extracted tunneling on arbitrary grid"""
+        self.logTestName()
         H = BosonOperator('0 1^', 0.5) + BosonOperator('0^ 1', 0.5)
         H += BosonOperator('0 2^', 0.5) + BosonOperator('0^ 2', 0.5)
         H += BosonOperator('1 2^', 0.5) + BosonOperator('1^ 2', 0.5)
         res = extract_tunneling(H)
+        res[0] = sorted(res[0], key=lambda x: x[0])
         expected = [[(0, 1), (0, 2), (1, 2)], -0.5]
         self.assertEqual(res, expected)
 
 
-class TestExtractOnsiteChemical(unittest.TestCase):
+class TestExtractOnsiteChemical(BaseTest):
     """Test Bose-Hubbard onsite interactions extracted from BosonOperator"""
     def test_incorrect_ladders(self):
         """Test exception raised for wrong ladder operators"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 0.1, 0.2)
             H -= BosonOperator('5^ 5^ 5^ 5^')
@@ -272,6 +298,7 @@ class TestExtractOnsiteChemical(unittest.TestCase):
 
     def test_too_many_terms(self):
         """Test exception raised for wrong number of terms"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 0.1, 0.2)
             H -= BosonOperator('0^ 0^ 0^ 0^')
@@ -284,6 +311,7 @@ class TestExtractOnsiteChemical(unittest.TestCase):
 
     def test_differing_chemical_potential(self):
         """Test exception raised for differing coefficients"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 0.1, 0.2)
             H -= BosonOperator('5^ 5')
@@ -291,6 +319,7 @@ class TestExtractOnsiteChemical(unittest.TestCase):
 
     def test_wrong_term_length(self):
         """Test exception raised for wrong terms"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 0.1, 0.2)
             H -= BosonOperator('5^ 5 5^')
@@ -299,6 +328,7 @@ class TestExtractOnsiteChemical(unittest.TestCase):
 
     def test_differing_onsite(self):
         """Test exception raised for differing coefficients"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 0.1, 0.2)
             H -= BosonOperator('5^ 5 5^ 5')
@@ -307,6 +337,7 @@ class TestExtractOnsiteChemical(unittest.TestCase):
 
     def test_only_chemical_potential(self):
         """Test case where there is non-zero mu and zero U"""
+        self.logTestName()
         H = bose_hubbard(2, 2, 1, 0, 0.2)
         res = extract_onsite_chemical(H)
         expected = ([], [[0, 1, 2, 3], 0.2])
@@ -314,6 +345,7 @@ class TestExtractOnsiteChemical(unittest.TestCase):
 
     def test_only_onsite(self):
         """Test case where there is zero mu and non-zero U"""
+        self.logTestName()
         H = bose_hubbard(2, 2, 1, 0.1, 0)
         res = extract_onsite_chemical(H)
         expected = ([[0, 1, 2, 3], 0.1], [])
@@ -321,22 +353,25 @@ class TestExtractOnsiteChemical(unittest.TestCase):
 
     def test_both(self):
         """Test case where there is non-zero mu and non-zero U"""
+        self.logTestName()
         H = bose_hubbard(2, 2, 1, 0.1, 0.2)
         res = extract_onsite_chemical(H)
         expected = ([[0, 1, 2, 3], 0.1], [[0, 1, 2, 3], 0.2])
         self.assertEqual(res, expected)
 
 
-class TestExtractDipole(unittest.TestCase):
+class TestExtractDipole(BaseTest):
     """Test Bose-Hubbard dipoles extracted from BosonOperator"""
     def test_no_dipole(self):
         """Test case where there is zero V"""
+        self.logTestName()
         H = bose_hubbard(2, 2, 1, 1, 1, 0)
         res = extract_dipole(H)
         self.assertEqual(res, [])
 
     def test_too_many_terms(self):
         """Test exception raised for wrong number of terms"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 1, 1, 0.5)
             H += BosonOperator('0^ 0 1^ 2', 0.5)
@@ -344,6 +379,7 @@ class TestExtractDipole(unittest.TestCase):
 
     def test_ladder_wrong_form(self):
         """Test exception raised for wrong ladder operators"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = bose_hubbard(2, 2, 1, 1, 1, 0.5)
             H += BosonOperator('5^ 5 6^ 6^')
@@ -352,6 +388,7 @@ class TestExtractDipole(unittest.TestCase):
 
     def test_coefficients_differ(self):
         """Test exception raised for differing coefficients"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = BosonOperator('0^ 0 1^ 1', 0.5)
             H += BosonOperator('0^ 0 2^ 2', 1)
@@ -359,20 +396,23 @@ class TestExtractDipole(unittest.TestCase):
 
     def test_2x2(self):
         """Test extracted dipole terms on 2x2 grid"""
+        self.logTestName()
         H = bose_hubbard(2, 2, 1, 0, 0, 0.5)
         res = extract_dipole(H)
+        res[0] = sorted(res[0], key=lambda x: x[0])
         expected = [[(0, 1), (0, 2), (1, 3), (2, 3)], 0.5]
         self.assertEqual(res, expected)
 
     def test_arbitrary(self):
         """Test extracted dipole terms on arbitrary grid"""
+        self.logTestName()
         H = BosonOperator('0^ 0 5^ 5', 0.1)
         res = extract_dipole(H)
         expected = [[(0, 5)], 0.1]
         self.assertEqual(res, expected)
 
 
-class TestTrotter(unittest.TestCase):
+class TestTrotter(BaseTest):
     """Test Bose-Hubbard trotter layers extracted from BosonOperator"""
     def setUp(self):
         """Test parameters"""
@@ -381,30 +421,29 @@ class TestTrotter(unittest.TestCase):
         self.mu = 0.25
         self.t = 1.068
         self.k = 20
+        self.V = 1/np.sqrt(3)
 
     def test_invalid(self):
         """Test exception raised for non-Bose-Hubbard Hamiltonian"""
+        self.logTestName()
         with self.assertRaises(BoseHubbardError):
             H = BosonOperator('0')
             _ = trotter_layer(H, self.t, self.k)
 
-    def test_dipole(self):
-        """Test exception raised for non-zero dipole terms"""
-        with self.assertRaises(BoseHubbardError):
-            H = bose_hubbard(2, 2, 1, 0.5, 0, 1)
-            _ = trotter_layer(H, self.t, self.k)
-
     def test_tunneling_2x2(self):
         """Test non-interacting 2x2 grid"""
+        self.logTestName()
         H = bose_hubbard(2, 2, self.J, 0, 0)
         res = trotter_layer(H, self.t, self.k)
         theta = -self.t*self.J/self.k
         phi = np.pi/2
         expected = {'BS': (theta, phi, [(0, 1), (0, 2), (1, 3), (2, 3)])}
+        res['BS'] = res['BS'][:2] + (sorted(res['BS'][2], key=lambda x: x[0]),)
         self.assertEqual(res, expected)
 
     def test_onsite_2x2(self):
         """Test on-site interacting 2x2 grid"""
+        self.logTestName()
         H = bose_hubbard(2, 2, self.J, self.U, 0)
         res = trotter_layer(H, self.t, self.k)
         theta = -self.t*self.J/self.k
@@ -416,10 +455,12 @@ class TestTrotter(unittest.TestCase):
             'K': (kappa, [0, 1, 2, 3]),
             'R': (r, [0, 1, 2, 3]),
         }
+        res['BS'] = res['BS'][:2] + (sorted(res['BS'][2], key=lambda x: x[0]),)
         self.assertEqual(res, expected)
 
     def test_chemical_potential_2x2(self):
         """Test on-site interacting and chemical potential on a 2x2 grid"""
+        self.logTestName()
         H = bose_hubbard(2, 2, self.J, self.U, self.mu)
         res = trotter_layer(H, self.t, self.k)
         theta = -self.t*self.J/self.k
@@ -431,16 +472,39 @@ class TestTrotter(unittest.TestCase):
             'K': (kappa, [0, 1, 2, 3]),
             'R': (r, [0, 1, 2, 3]),
         }
+        res['BS'] = res['BS'][:2] + (sorted(res['BS'][2], key=lambda x: x[0]),)
         self.assertEqual(res, expected)
 
+    def test_dipole_2x2(self):
+        """Test on-site interacting and dipole interactions on a 2x2 grid"""
+        self.logTestName()
+        H = bose_hubbard(2, 2, self.J, self.U, 0, self.V)
+        res = trotter_layer(H, self.t, self.k)
+        theta = -self.t*self.J/self.k
+        ckappa = -self.V*self.t/self.k
+        phi = np.pi/2
+        kappa = -self.t*self.U/(2*self.k)
+        r = -kappa
+        expected = {
+            'BS': (theta, phi, [(0, 1), (0, 2), (1, 3), (2, 3)]),
+            'CK': (ckappa, [(0, 1), (0, 2), (1, 3), (2, 3)]),
+            'K': (kappa, [0, 1, 2, 3]),
+            'R': (r, [0, 1, 2, 3]),
+        }
+        res['BS'] = res['BS'][:-1] + (sorted(res['BS'][-1], key=lambda x: x[0]),)
+        res['CK'] = res['CK'][:-1] + (sorted(res['CK'][-1], key=lambda x: x[0]),)
+        self.assertEqual(res, expected)
 
     def test_arbitrary(self):
         """Test on-site interacting and chemical potential on a 3-cycle"""
+        self.logTestName()
         H = BosonOperator('0 1^', -self.J) + BosonOperator('0^ 1', -self.J)
         H += BosonOperator('0 2^', -self.J) + BosonOperator('0^ 2', -self.J)
         H += BosonOperator('1 2^', -self.J) + BosonOperator('1^ 2', -self.J)
 
         res = trotter_layer(H, self.t, self.k)
+        res['BS'] = res['BS'][:2] + (sorted(res['BS'][2], key=lambda x: x[0]),)
+
         theta = -self.t*self.J/self.k
         phi = np.pi/2
         expected = {'BS': (theta, phi, [(0, 1), (0, 2), (1, 2)])}
@@ -458,6 +522,8 @@ class TestTrotter(unittest.TestCase):
             'R': (r, [0, 1, 2]),
         }
         res = trotter_layer(H, self.t, self.k)
+
+        res['BS'] = res['BS'][:2] + (sorted(res['BS'][2], key=lambda x: x[0]),)
         self.assertEqual(res, expected)
 
 

--- a/sfopenboson/tests/test_bose_hubbard_prop.py
+++ b/sfopenboson/tests/test_bose_hubbard_prop.py
@@ -37,6 +37,7 @@ class TestBoseHubbardPropagation(BaseTest):
         self.eng, _ = sf.Engine(2, hbar=self.hbar)
         self.J = -1
         self.U = 1.5
+        self.V = 1/np.sqrt(2)
         self.t = 1.086
         self.k = 20
         self.tol = 1e-2
@@ -77,6 +78,28 @@ class TestBoseHubbardPropagation(BaseTest):
 
         Hm = -self.J*np.sqrt(2)*np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]]) \
             + self.U*np.diag([1, 0, 1])
+        init_state = np.array([1, 0, 0])
+        exp = np.abs(np.dot(expm(-1j*self.t*Hm), init_state))**2
+
+        self.assertTrue(np.allclose(state.fock_prob([2, 0]), exp[0], rtol=self.tol))
+        self.assertTrue(np.allclose(state.fock_prob([1, 1]), exp[1], rtol=self.tol))
+        self.assertTrue(np.allclose(state.fock_prob([0, 2]), exp[2], rtol=self.tol))
+
+    def test_1x2_dipole(self):
+        """Test a 1x2 lattice Bose-Hubbard model with nearest-neighbour interactions"""
+        self.logTestName()
+        self.eng.reset()
+        q = self.eng.register
+        H = bose_hubbard(1, 2, self.J, self.U, 0, self.V)
+
+        with self.eng:
+            Fock(2) | q[0]
+            BoseHubbardPropagation(H, self.t, self.k) | q
+
+        state = self.eng.run('fock', cutoff_dim=7)
+
+        Hm = -self.J*np.sqrt(2)*np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]]) \
+            + self.U*np.diag([1, 0, 1]) + self.V*np.diag([0, 1, 0])
         init_state = np.array([1, 0, 0])
         exp = np.abs(np.dot(expm(-1j*self.t*Hm), init_state))**2
 

--- a/sfopenboson/tests/test_gates.py
+++ b/sfopenboson/tests/test_gates.py
@@ -34,8 +34,10 @@ from sfopenboson.hamiltonians import (displacement,
                                       cubic_phase,
                                       kerr)
 
+from sfopenboson.tests import BaseTest
 
-class TestDisplacement(unittest.TestCase):
+
+class TestDisplacement(BaseTest):
     """Tests for Displacement function"""
     def setUp(self):
         """parameters"""
@@ -44,29 +46,34 @@ class TestDisplacement(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         H, r = displacement(0, hbar=self.hbar)
         self.assertEqual(H, BosonOperator.identity())
         self.assertEqual(r, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         H, _ = displacement(self.alpha, hbar=self.hbar)
         self.assertTrue(is_hermitian(H))
         self.assertTrue(is_hermitian(get_quad_operator(H)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         H, _ = displacement(self.alpha, hbar=self.hbar)
         res = get_quad_operator(H, hbar=self.hbar).is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         _, r = displacement(self.alpha)
         self.assertEqual(r, np.abs(self.alpha))
 
     def test_coefficients(self):
         """Test coefficients are correct"""
+        self.logTestName()
         H, _ = displacement(self.alpha, hbar=self.hbar)
         phi = np.angle(self.alpha)
 
@@ -77,7 +84,7 @@ class TestDisplacement(unittest.TestCase):
             self.assertEqual(coeff, 1j*expected)
 
 
-class TestXDisplacement(unittest.TestCase):
+class TestXDisplacement(BaseTest):
     """Tests for x displacement function"""
     def setUp(self):
         """parameters"""
@@ -86,33 +93,38 @@ class TestXDisplacement(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, r = xdisplacement(0)
         self.assertEqual(r, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         H, _ = xdisplacement(self.x)
         self.assertTrue(is_hermitian(H))
         self.assertTrue(is_hermitian(get_boson_operator(H, hbar=self.hbar)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         H, _ = xdisplacement(self.x)
         res = H.is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         _, r = xdisplacement(self.x)
         self.assertEqual(r, self.x)
 
     def test_coefficients(self):
         """Test coefficients are correct"""
+        self.logTestName()
         H, _ = xdisplacement(self.x)
         self.assertEqual(H, QuadOperator('p0', 1))
 
 
-class TestZDisplacement(unittest.TestCase):
+class TestZDisplacement(BaseTest):
     """Tests for z displacement function"""
     def setUp(self):
         """Parameters"""
@@ -121,33 +133,38 @@ class TestZDisplacement(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, r = zdisplacement(0)
         self.assertEqual(r, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         H, _ = zdisplacement(self.p)
         self.assertTrue(is_hermitian(H))
         self.assertTrue(is_hermitian(get_boson_operator(H, hbar=self.hbar)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         H, _ = zdisplacement(self.p)
         res = H.is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         _, r = zdisplacement(self.p)
         self.assertEqual(r, self.p)
 
     def test_coefficients(self):
         """Test coefficients are correct"""
+        self.logTestName()
         H, _ = zdisplacement(self.p)
         self.assertEqual(H, -QuadOperator('q0', 1))
 
 
-class TestRotation(unittest.TestCase):
+class TestRotation(BaseTest):
     """Tests for rotation function"""
     def setUp(self):
         """Parameters"""
@@ -156,33 +173,39 @@ class TestRotation(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, r = rotation(0)
         self.assertEqual(r, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         H, _ = rotation(self.phi, hbar=self.hbar)
         self.assertTrue(is_hermitian(H))
         self.assertTrue(is_hermitian(get_quad_operator(H)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         H, _ = rotation(self.phi, hbar=self.hbar)
         res = get_quad_operator(H, hbar=self.hbar).is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         _, r = rotation(self.phi, hbar=self.hbar)
         self.assertEqual(r, self.phi)
 
     def test_coefficients(self):
         """Test coefficients are correct"""
+        self.logTestName()
         H, _ = rotation(self.phi, hbar=self.hbar)
         self.assertEqual(H, -BosonOperator('0^ 0')*self.hbar)
 
     def test_quad_form(self):
         """Test it has the correct form using quadrature operators"""
+        self.logTestName()
         H, _ = rotation(self.phi, mode=1, hbar=self.hbar)
         H = normal_ordered(get_quad_operator(H, hbar=self.hbar), hbar=self.hbar)
         expected = QuadOperator('q1 q1', -0.5)
@@ -191,7 +214,7 @@ class TestRotation(unittest.TestCase):
         self.assertEqual(H, expected)
 
 
-class TestSqueezing(unittest.TestCase):
+class TestSqueezing(BaseTest):
     """Tests for squeezing function"""
     def setUp(self):
         """Parameters"""
@@ -202,25 +225,30 @@ class TestSqueezing(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, t = squeezing(0)
         self.assertEqual(t, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         self.assertTrue(is_hermitian(self.H))
         self.assertTrue(is_hermitian(get_quad_operator(self.H)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         res = get_quad_operator(self.H).is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         self.assertEqual(self.t, self.r)
 
     def test_quad_form(self):
         """Test it has the correct form using quadrature operators"""
+        self.logTestName()
         H, _ = squeezing(2, mode=1)
         H = normal_ordered(get_quad_operator(H, hbar=self.hbar), hbar=self.hbar)
         expected = QuadOperator('q1 p1', -1)
@@ -228,7 +256,7 @@ class TestSqueezing(unittest.TestCase):
         self.assertEqual(H, expected)
 
 
-class TestQuadraticPhase(unittest.TestCase):
+class TestQuadraticPhase(BaseTest):
     """Tests for quadratic phase function"""
     def setUp(self):
         """Parameters"""
@@ -238,25 +266,30 @@ class TestQuadraticPhase(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, t = quadratic_phase(0)
         self.assertEqual(t, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         self.assertTrue(is_hermitian(self.H))
         self.assertTrue(is_hermitian(get_boson_operator(self.H, hbar=self.hbar)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         res = self.H.is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         self.assertEqual(self.t, self.s)
 
     def test_boson_form(self):
         """Test bosonic form is correct"""
+        self.logTestName()
         H = normal_ordered(get_boson_operator(self.H, hbar=self.hbar))
         expected = BosonOperator('0 0', -0.5)
         expected += BosonOperator('0^ 0', -1)
@@ -265,7 +298,7 @@ class TestQuadraticPhase(unittest.TestCase):
         self.assertEqual(H, expected)
 
 
-class TestBeamsplitter(unittest.TestCase):
+class TestBeamsplitter(BaseTest):
     """Tests for beamsplitter function"""
     def setUp(self):
         """Parameters"""
@@ -276,25 +309,30 @@ class TestBeamsplitter(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, t = beamsplitter(0, 0)
         self.assertEqual(t, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         self.assertTrue(is_hermitian(self.H))
         self.assertTrue(is_hermitian(get_quad_operator(self.H)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         res = get_quad_operator(self.H).is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         self.assertEqual(self.t, self.theta)
 
     def test_quad_form(self):
         """Test it has the correct form using quadrature operators"""
+        self.logTestName()
         H, _ = beamsplitter(np.pi/4, np.pi/2, mode1=1, mode2=3, hbar=self.hbar)
         H = normal_ordered(get_quad_operator(H, hbar=self.hbar), hbar=self.hbar)
         expected = QuadOperator('q1 q3', -1)
@@ -302,7 +340,7 @@ class TestBeamsplitter(unittest.TestCase):
         self.assertEqual(H, expected)
 
 
-class TestTwoModeSqueezing(unittest.TestCase):
+class TestTwoModeSqueezing(BaseTest):
     """Tests for two-mode squeezing function"""
     def setUp(self):
         """Parameters"""
@@ -313,25 +351,30 @@ class TestTwoModeSqueezing(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, t = two_mode_squeezing(0)
         self.assertEqual(t, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         self.assertTrue(is_hermitian(self.H))
         self.assertTrue(is_hermitian(get_quad_operator(self.H)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         res = get_quad_operator(self.H).is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         self.assertEqual(self.t, self.r)
 
     def test_quad_form(self):
         """Test it has the correct form using quadrature operators"""
+        self.logTestName()
         H, _ = two_mode_squeezing(2, mode1=1, mode2=3, hbar=self.hbar)
         H = normal_ordered(get_quad_operator(H, hbar=self.hbar), hbar=self.hbar)
         expected = QuadOperator('q1 p3', 1)
@@ -339,7 +382,7 @@ class TestTwoModeSqueezing(unittest.TestCase):
         self.assertEqual(H, expected)
 
 
-class TestControlledAddition(unittest.TestCase):
+class TestControlledAddition(BaseTest):
     """Tests for controlled addition function"""
     def setUp(self):
         """Parameters"""
@@ -349,25 +392,30 @@ class TestControlledAddition(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, t = controlled_addition(0)
         self.assertEqual(t, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         self.assertTrue(is_hermitian(self.H))
         self.assertTrue(is_hermitian(get_boson_operator(self.H, hbar=self.hbar)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         res = self.H.is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         self.assertEqual(self.t, self.s)
 
     def test_boson_form(self):
         """Test bosonic form is correct"""
+        self.logTestName()
         H = normal_ordered(get_boson_operator(self.H, hbar=self.hbar))
         expected = BosonOperator('0 1', -1j)
         expected += BosonOperator('0 1^', 1j)
@@ -376,7 +424,7 @@ class TestControlledAddition(unittest.TestCase):
         self.assertEqual(H, expected)
 
 
-class TestControlledPhase(unittest.TestCase):
+class TestControlledPhase(BaseTest):
     """Tests for controlled phase function"""
     def setUp(self):
         """Parameters"""
@@ -386,25 +434,30 @@ class TestControlledPhase(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, t = controlled_phase(0)
         self.assertEqual(t, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         self.assertTrue(is_hermitian(self.H))
         self.assertTrue(is_hermitian(get_boson_operator(self.H, hbar=self.hbar)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         res = self.H.is_gaussian()
         self.assertTrue(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         self.assertEqual(self.t, self.s)
 
     def test_boson_form(self):
         """Test bosonic form is correct"""
+        self.logTestName()
         H = normal_ordered(get_boson_operator(self.H, hbar=self.hbar))
         expected = BosonOperator('0 1', -1)
         expected += BosonOperator('0 1^', -1)
@@ -413,7 +466,7 @@ class TestControlledPhase(unittest.TestCase):
         self.assertEqual(H, expected)
 
 
-class TestCubicPhase(unittest.TestCase):
+class TestCubicPhase(BaseTest):
     """Tests for cubic phase function"""
     def setUp(self):
         """Parameters"""
@@ -423,25 +476,29 @@ class TestCubicPhase(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, t = cubic_phase(0)
         self.assertEqual(t, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         self.assertTrue(is_hermitian(self.H))
         self.assertTrue(is_hermitian(get_boson_operator(self.H, hbar=self.hbar)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         res = self.H.is_gaussian()
         self.assertFalse(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         self.assertEqual(self.t, self.gamma)
 
 
-class TestKerr(unittest.TestCase):
+class TestKerr(BaseTest):
     """Tests for Kerr function"""
     def setUp(self):
         """Parameters"""
@@ -451,21 +508,25 @@ class TestKerr(unittest.TestCase):
 
     def test_identity(self):
         """Test alpha=0 gives identity"""
+        self.logTestName()
         _, t = two_mode_squeezing(0)
         self.assertEqual(t, 0)
 
     def test_hermitian(self):
         """Test output is hermitian"""
+        self.logTestName()
         self.assertTrue(is_hermitian(self.H))
         self.assertTrue(is_hermitian(get_quad_operator(self.H)))
 
     def test_gaussian(self):
         """Test output is gaussian"""
+        self.logTestName()
         res = get_quad_operator(self.H).is_gaussian()
         self.assertFalse(res)
 
     def test_time(self):
         """Test time parameter is correct"""
+        self.logTestName()
         self.assertEqual(self.t, self.kappa)
 
 

--- a/sfopenboson/tests/test_gaussian_prop.py
+++ b/sfopenboson/tests/test_gaussian_prop.py
@@ -40,9 +40,10 @@ from sfopenboson.hamiltonians import (displacement,
                                       controlled_phase)
 
 from sfopenboson.ops import GaussianPropagation
+from sfopenboson.tests import BaseTest
 
 
-class TestSingularCoefficients(unittest.TestCase):
+class TestSingularCoefficients(BaseTest):
     """Tests using singular Hamiltonians"""
     def setUp(self):
         """parameters"""
@@ -52,6 +53,7 @@ class TestSingularCoefficients(unittest.TestCase):
 
     def test_singular_coefficients(self):
         """Test that H=p^2/2+q has displacement (q,t)=(-t^2,-t)"""
+        self.logTestName()
         self.eng.reset()
         q = self.eng.register
 
@@ -66,7 +68,7 @@ class TestSingularCoefficients(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
 
-class TestSingleModeGaussianGates(unittest.TestCase):
+class TestSingleModeGaussianGates(BaseTest):
     """Tests using single mode Gaussian gates"""
     def setUp(self):
         """parameters"""
@@ -75,6 +77,7 @@ class TestSingleModeGaussianGates(unittest.TestCase):
 
     def test_squeezing(self):
         """Test squeezing gives correct means and cov"""
+        self.logTestName()
         self.eng.reset()
         q = self.eng.register
 
@@ -104,6 +107,7 @@ class TestSingleModeGaussianGates(unittest.TestCase):
 
     def test_rotation(self):
         """Test rotation gives correct means and cov"""
+        self.logTestName()
         self.eng.reset()
         q = self.eng.register
 
@@ -133,6 +137,7 @@ class TestSingleModeGaussianGates(unittest.TestCase):
 
     def test_quadratic_phase(self):
         """Test quadratic phase gives correct means and cov"""
+        self.logTestName()
         self.eng.reset()
         q = self.eng.register
 
@@ -160,6 +165,7 @@ class TestSingleModeGaussianGates(unittest.TestCase):
 
     def test_displacement(self):
         """Test displacement gives correct means and cov"""
+        self.logTestName()
         self.eng.reset()
         q = self.eng.register
 
@@ -193,7 +199,7 @@ def init_layer(q):
     return q
 
 
-class TestTwoModeGaussianGatesLocal(unittest.TestCase):
+class TestTwoModeGaussianGatesLocal(BaseTest):
     """Tests for two mode Gaussian gates in local mode"""
     def setUp(self):
         """parameters"""
@@ -229,6 +235,7 @@ class TestTwoModeGaussianGatesLocal(unittest.TestCase):
 
     def test_beamsplitter(self):
         """Test beamsplitter produces correct cov and means"""
+        self.logTestName()
         self.eng.reset()
 
         H, t = beamsplitter(self.th, self.phi, hbar=self.hbar)
@@ -244,6 +251,7 @@ class TestTwoModeGaussianGatesLocal(unittest.TestCase):
 
     def test_two_mode_squeezing(self):
         """Test S2gate produces correct cov and means"""
+        self.logTestName()
         # NOTE: There is currently a bug in strawberry fields,
         # where the Bloch-Messiah decomposition returns an
         # incorrect result for matrices with degenerate eigenvalues.
@@ -262,6 +270,7 @@ class TestTwoModeGaussianGatesLocal(unittest.TestCase):
 
     def test_controlled_addition(self):
         """Test CXgate produces correct cov and means"""
+        self.logTestName()
         self.eng.reset()
 
         H, t = controlled_addition(self.r)
@@ -277,6 +286,7 @@ class TestTwoModeGaussianGatesLocal(unittest.TestCase):
 
     def test_controlled_phase(self):
         """Test CZgate produces correct cov and means"""
+        self.logTestName()
         self.eng.reset()
 
         H, t = controlled_phase(self.r)
@@ -291,7 +301,7 @@ class TestTwoModeGaussianGatesLocal(unittest.TestCase):
         self.assertTrue(np.allclose(resD, expD))
 
 
-class TestTwoModeGaussianGatesGlobal(unittest.TestCase):
+class TestTwoModeGaussianGatesGlobal(BaseTest):
     """Tests for two mode Gaussian gates in global mode"""
     def setUp(self):
         """parameters"""
@@ -331,6 +341,7 @@ class TestTwoModeGaussianGatesGlobal(unittest.TestCase):
 
     def test_single_mode_gate(self):
         """Test Rgate gives correct means and cov in global mode"""
+        self.logTestName()
         self.eng.reset()
         q = self.eng.register
 
@@ -347,6 +358,7 @@ class TestTwoModeGaussianGatesGlobal(unittest.TestCase):
 
     def test_two_mode_gate(self):
         """Test S2gate gives correct means and cov in global mode"""
+        self.logTestName()
         self.eng.reset()
         q = self.eng.register
 
@@ -362,7 +374,7 @@ class TestTwoModeGaussianGatesGlobal(unittest.TestCase):
         self.assertTrue(np.allclose(resD, expD))
 
 
-class TestQuadraticAndLinear(unittest.TestCase):
+class TestQuadraticAndLinear(BaseTest):
     """Tests for Hamiltonians with quadratic and linear coefficients"""
     def setUp(self):
         """parameters"""
@@ -384,6 +396,7 @@ class TestQuadraticAndLinear(unittest.TestCase):
 
     def test_displaced_oscillator(self):
         """Test that a forced quantum oscillator produces the correct
+        self.logTestName()
         trajectory in the phase space"""
         H = QuadOperator('q0 q0', 0.5)
         H += QuadOperator('p0 p0', 0.5)
@@ -408,7 +421,7 @@ class TestQuadraticAndLinear(unittest.TestCase):
         self.assertTrue(np.allclose(res, expected))
 
 
-class TestToolchain(unittest.TestCase):
+class TestToolchain(BaseTest):
     """Tests for the GaussianPropagation toolchain"""
     def setUp(self):
         """parameters"""
@@ -430,6 +443,7 @@ class TestToolchain(unittest.TestCase):
 
     def test_outside_context(self):
         """test setting hbar outside of engine context"""
+        self.logTestName()
         H, t = rotation(self.phi)
         Ugate = GaussianPropagation(H, t, hbar=self.hbar)
         resD, resV = self.ref_circuit(Ugate)
@@ -442,12 +456,14 @@ class TestToolchain(unittest.TestCase):
 
     def test_outside_context_no_hbar(self):
         """test exception if no hbar outside of engine context"""
+        self.logTestName()
         with self.assertRaises(ValueError):
             H, t = rotation(self.phi)
             GaussianPropagation(H, t)
 
     def test_non_hermitian(self):
         """test exception if H is not hermitian"""
+        self.logTestName()
         with self.assertRaises(ValueError):
             H = QuadOperator('q0', 1+2j)
             GaussianPropagation(H, hbar=2.)


### PR DESCRIPTION
In Strawberry Fields 0.8, the Cross-Kerr interaction was introduced as a basic quantum operation. As a result, we can now support Bose-Hubbard propagation with nearest-neighbour interactions.

This pull request introduces nearest-neighbour support, as well as various bug fixes to ensure OpenBoson works well with Strawberry Fields version 0.8 (including a bug fix for #1).

As a result, I have bumped the version number up to v0.2.